### PR TITLE
Updated README.md

### DIFF
--- a/Wavefront-DT/dropwizard-app/README.md
+++ b/Wavefront-DT/dropwizard-app/README.md
@@ -49,8 +49,21 @@ This is a sample Java application using Dropwizard called beachshirts (#[beachop
 
 **Option A** - If you are sending data to Wavefront via Direct Ingestion, then make sure you have the cluster name and corresponding token from [https://{cluster}.wavefront.com/settings/profile](https://{cluster}.wavefront.com/settings/profile).
 
-Now go to `dropwizard-app/common/../Tracing.java` and change the `Tracer init(String service)` method to return a [WavefrontTracer](https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java#set-up-a-tracer) as follows:
+Now go to `dropwizard-app/common/../Tracing.java` and change the `Tracer init(String service)` method to return a [Wa vefrontTracer](https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java#set-up-a-tracer) as follows:
 
+In the import section of the code (at line 13), add the following imports.
+   ```java
+      import com.wavefront.opentracing.WavefrontTracer;
+      import com.wavefront.opentracing.reporting.Reporter;
+      import com.wavefront.opentracing.reporting.WavefrontSpanReporter;
+      import com.wavefront.sdk.common.WavefrontSender;
+      import com.wavefront.sdk.common.application.ApplicationTags;
+      import com.wavefront.sdk.direct.ingestion.WavefrontDirectIngestionClient;
+      import com.wavefront.sdk.proxy.WavefrontProxyClient;
+   ```
+
+Modify the init() method with the following snippet:
+   
    ```java
    public static Tracer init(String service) {
     // TODO: Replace {cluster} with your wavefront URL and obtain wavefront API token
@@ -101,6 +114,19 @@ Now go to `dropwizard-app/common/../Tracing.java` and change the `Tracer init(St
      
 Now go to `dropwizard-app/common/../Tracing.java` and change the `Tracer init(String service)` method to return a [WavefrontTracer](https://github.com/wavefrontHQ/wavefront-opentracing-sdk-java#set-up-a-tracer) as follows:
 
+In the import section of the code (line 13), add the following imports.
+   ```java
+      import com.wavefront.opentracing.WavefrontTracer;
+      import com.wavefront.opentracing.reporting.Reporter;
+      import com.wavefront.opentracing.reporting.WavefrontSpanReporter;
+      import com.wavefront.sdk.common.WavefrontSender;
+      import com.wavefront.sdk.common.application.ApplicationTags;
+      import com.wavefront.sdk.direct.ingestion.WavefrontDirectIngestionClient;
+      import com.wavefront.sdk.proxy.WavefrontProxyClient;
+   ```
+
+Modify the init() method with the following snippet:
+
    ```java
    public static Tracer init(String service) {
        WavefrontProxyClient.Builder wfProxyClientBuilder = new WavefrontProxyClient.
@@ -123,25 +149,13 @@ Now go to `dropwizard-app/common/../Tracing.java` and change the `Tracer init(St
 
    After making all the code changes, run `mvn clean install` from the root directory of the project.
 
-3. Make sure you add the following imports to `dropwizard-app/common/../Tracing.java`:
-
-   ```java
-   import com.wavefront.opentracing.WavefrontTracer;
-   import com.wavefront.opentracing.reporting.Reporter;
-   import com.wavefront.opentracing.reporting.WavefrontSpanReporter;
-   import com.wavefront.sdk.common.WavefrontSender;
-   import com.wavefront.sdk.common.application.ApplicationTags;
-   import com.wavefront.sdk.direct.ingestion.WavefrontDirectIngestionClient;
-   import com.wavefront.sdk.proxy.WavefrontProxyClient;
-   ```
-
-4. Now restart all the services again using below commands from root directory of the project.
+3. Now restart all the services again using below commands from root directory of the project.
 
    ```bash
    java -jar ./shopping/target/shopping-1.0-SNAPSHOT.jar server ./shopping/app.yaml
    java -jar ./styling/target/styling-1.0-SNAPSHOT.jar server ./styling/app.yaml
    java -jar ./delivery/target/delivery-1.0-SNAPSHOT.jar server ./delivery/app.yaml
    ```
-5. Generate some load via loadgen - Use `./loadgen.sh {interval}` in the root directory to send a request of ordering shirts every `{interval}` seconds.
+4. Generate some load via loadgen - Use `./loadgen.sh {interval}` in the root directory to send a request of ordering shirts every `{interval}` seconds.
 
-6. Go to **Applications -> Traces** in the Wavefront UI to visualize your traces. You can also go to **Applications -> Inventory** to visualize the RED metrics that are automatically derived from your tracing spans.
+5. Go to **Applications -> Traces** in the Wavefront UI to visualize your traces. You can also go to **Applications -> Inventory** to visualize the RED metrics that are automatically derived from your tracing spans.


### PR DESCRIPTION
updated parts of copying and pasting java codes to clarify you need to include import statements as well as the code snippet. The current readme has that instruction after the mvn install command where it doesn't make sense, and will result in compilation errors if they do not import those statements.